### PR TITLE
Install systemd units separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,12 @@ udp514-journal: udp514-journal.c udp514-journal.h version.h
 README.html: README.md
 	$(MD) README.md > README.html
 
-install: install-bin install-doc
+install: install-bin install-doc install-units
 
 install-bin: udp514-journal
 	$(INSTALL) -D -m0755 udp514-journal $(DESTDIR)/usr/bin/udp514-journal
+
+install-units:
 	$(INSTALL) -D -m0644 udp514-journal.service $(DESTDIR)/usr/lib/systemd/system/udp514-journal.service
 	$(INSTALL) -D -m0644 udp514-journal.socket $(DESTDIR)/usr/lib/systemd/system/udp514-journal.socket
 


### PR DESCRIPTION
I would like to wrap it as package for NixOS.
However NixOS doesn't use upstream-provided systemd units - they define units directly in Nix config.

This PR moves installation of systemd units unter separate make target, so I can install only bin and doc outputs.