### PR TITLE
Added code to exclude remote timestamp information

### DIFF
--- a/udp514-journal.c
+++ b/udp514-journal.c
@@ -18,6 +18,37 @@
 
 #include "udp514-journal.h"
 
+static char *strip_syslog_header(char *msg) {
+	char *p = msg;
+
+	/* strip <PRI> */
+	if (*p == '<') {
+		char *end = strchr(p, '>');
+		if (end)
+			p = end + 1;
+	}
+
+	/* RFC3164: "MMM DD HH:MM:SS " */
+	if (strlen(p) >= 16 &&
+	    isalpha((unsigned char)p[0]) &&
+	    isalpha((unsigned char)p[1]) &&
+	    isalpha((unsigned char)p[2]) &&
+	    p[3] == ' ' &&
+	    isdigit((unsigned char)p[4])) {
+		p += 16;
+		return p;
+	}
+
+	/* RFC5424: "1 2025-12-19T11:13:52Z " */
+	if (isdigit((unsigned char)p[0]) && p[1] == ' ') {
+		char *ts_end = strchr(p + 2, ' ');
+		if (ts_end)
+			p = ts_end + 1;
+	}
+
+	return p;
+}
+
 int main(int argc, char **argv) {
 	int activation, sock;
 	unsigned int count = 0;
@@ -120,8 +151,10 @@ int main(int argc, char **argv) {
 			continue;
 		}
 
+		char *clean_msg = strip_syslog_header(msg_buf);
+
 		/* send to systemd-journald */
-		sd_journal_send("MESSAGE=%s", msg_buf,
+		sd_journal_send("MESSAGE=%s", clean_msg,
 			"SYSLOG_IDENTIFIER=%s", address,
 			"PRIORITY=%i", priority,
 			NULL);

--- a/udp514-journal.h
+++ b/udp514-journal.h
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <time.h>
+#include <ctype.h>
 
 #define SYSLOG_NAMES
 #define __USE_MISC


### PR DESCRIPTION
Firstly thank you so much for your code, I was having huge troubles with rsyslog looping JournalD messages when I enabled the omjournal module.

Since the OpenMediaVault Debian package depends on rsyslog I couldn't simply replace it with another syslog package.

However I noticed upd514-journal was sending everything it gets to JournalD, including the remote timestamp, which is unnecessary as JournalD adds it's own server time information to logs.

Busybox on my router running OpenWRT uses RFC3164 (from 2001) timestamps, but the PR also supports RFC5424 (from 2009) formatted timestamps in case Busybox ever updates to the newer format but that seems unlikely, however others may need it.